### PR TITLE
Fix C++ warning of missing initializer

### DIFF
--- a/include/smf/smf.h
+++ b/include/smf/smf.h
@@ -37,7 +37,8 @@
 { \
 	.entry = _entry, \
 	.run   = _run,   \
-	.exit  = _exit   \
+	.exit  = _exit,  \
+	.parent = NULL   \
 }
 
 #endif /* CONFIG_SMF_ANCESTOR_SUPPORT */


### PR DESCRIPTION
Hello @oldrev,

First thank you for you effort of porting the ZephyrRTOS SMF to ESP-IDF.

By this PR I wanted to fix a simple C++ warning when building the project.

**When using the component in a C++ project I get the following warning.**

```
src/Apps/App.cpp:55:1: warning: missing initializer for member 'smf_state::parent' [-Wmissing-field-initializers]
   55 | };
      | ^
src/Apps/App.cpp:55:1: warning: missing initializer for member 'smf_state::parent' [-Wmissing-field-initializers]
```

**To resolve that we need to explicitly initialize all members of the structure including the parent member like the follwoing:**

```c
/**
 * @brief Macro to create a flat state.
 *
 * @param _entry  State entry function
 * @param _run  State run function
 * @param _exit  State exit function
 */
#define SMF_CREATE_STATE(_entry, _run, _exit) \
{ \
	.entry = _entry, \
	.run   = _run,   \
	.exit  = _exit,  \
	.parent = NULL   \
}
```

Best regards
Bayrem